### PR TITLE
Remove the 'active draft' concept

### DIFF
--- a/dbs/archive-drafts.js
+++ b/dbs/archive-drafts.js
@@ -6,13 +6,9 @@ const archivesDb = require('./archives')
 
 exports.list = async function (profileId, masterKey) {
   // get draft list
-  var records = await db.all(`SELECT draftKey as key, isActive FROM archive_drafts WHERE profileId = ? AND masterKey = ? ORDER BY createdAt`, [profileId, masterKey])
+  var records = await db.all(`SELECT draftKey as key FROM archive_drafts WHERE profileId = ? AND masterKey = ? ORDER BY createdAt`, [profileId, masterKey])
   // fetch full info from archives db
-  return Promise.all(records.map(async ({key, isActive}) => {
-    var record = await archivesDb.query(profileId, {key, showHidden: true})
-    record.isActiveDraft = !!isActive
-    return record
-  }))
+  return Promise.all(records.map(async ({key}) => await archivesDb.query(profileId, {key, showHidden: true})))
 }
 
 exports.add = function (profileId, masterKey, draftKey) {
@@ -25,17 +21,6 @@ exports.add = function (profileId, masterKey, draftKey) {
 
 exports.remove = function (profileId, masterKey, draftKey) {
   return db.run(`DELETE FROM archive_drafts WHERE profileId = ? AND masterKey = ? AND draftKey = ?`, [profileId, masterKey, draftKey])
-}
-
-exports.getActiveDraft = async function (profileId, masterKey) {
-  var record = await db.get(`SELECT draftKey as key FROM archive_drafts WHERE profileId = ? AND masterKey = ? AND isActive = 1`, [profileId, masterKey])
-  if (record) return record.key
-  return masterKey
-}
-
-exports.setActiveDraft = async function (profileId, masterKey, draftKey) {
-  await db.run(`UPDATE archive_drafts SET isActive = 0 WHERE profileId = ? AND masterKey = ?`, [profileId, masterKey])
-  await db.run(`UPDATE archive_drafts SET isActive = 1 WHERE profileId = ? AND masterKey = ? AND draftKey = ?`, [profileId, masterKey, draftKey])
 }
 
 exports.getMaster = async function (profileId, draftKey) {

--- a/dbs/archives.js
+++ b/dbs/archives.js
@@ -398,6 +398,18 @@ exports.setMeta = async function (key, value = {}) {
   events.emit('update:archive-meta', key, value)
 }
 
+// find the archive currently using a given localSyncPath
+exports.getByLocalSyncPath = async function (profileId, localSyncPath) {
+  try {
+    return await db.get(`
+      SELECT key FROM archives WHERE profileId = ? AND localSyncPath = ?
+    `, [profileId, localSyncPath])
+    return settings
+  } catch (e) {
+    return null
+  }
+}
+
 // internal methods
 // =
 

--- a/dbs/schemas/profile-data.sql.js
+++ b/dbs/schemas/profile-data.sql.js
@@ -46,8 +46,9 @@ CREATE TABLE archive_drafts (
   profileId INTEGER,
   masterKey TEXT, -- key of the master dat
   draftKey TEXT, -- key of the draft dat
-  isActive INTEGER, -- is this the active draft?
   createdAt INTEGER DEFAULT (strftime('%s', 'now')),
+
+  isActive INTEGER, -- is this the active draft? (deprecated)
 
   FOREIGN KEY (profileId) REFERENCES profiles (id) ON DELETE CASCADE
 );

--- a/dbs/schemas/profile-data.v19.sql.js
+++ b/dbs/schemas/profile-data.v19.sql.js
@@ -8,8 +8,9 @@ CREATE TABLE archive_drafts (
   profileId INTEGER,
   masterKey TEXT, -- key of the master dat
   draftKey TEXT, -- key of the draft dat
-  isActive INTEGER, -- is this the active draft?
   createdAt INTEGER DEFAULT (strftime('%s', 'now')),
+  
+  isActive INTEGER, -- is this the active draft? (deprecated)
 
   FOREIGN KEY (profileId) REFERENCES profiles (id) ON DELETE CASCADE
 );

--- a/web-apis/bg/archives.js
+++ b/web-apis/bg/archives.js
@@ -132,6 +132,13 @@ module.exports = {
       }
     }
 
+    // check whether it's already in use
+    var archiveRecord = await archivesDb.getByLocalSyncPath(0, localSyncPath)
+    if (archiveRecord && archiveRecord.key === key) return // noop, already set
+    if (archiveRecord) {
+      await archivesDb.setUserSettings(0, archiveRecord.key, {localSyncPath: ''})
+    }
+
     // update the record
     await archivesDb.setUserSettings(0, key, {localSyncPath})
   },

--- a/web-apis/fg/beaker.js
+++ b/web-apis/fg/beaker.js
@@ -49,7 +49,6 @@ exports.setup = function (rpc) {
     beaker.archives.ensureLocalSyncFinished = archivesRPC.ensureLocalSyncFinished
     beaker.archives.getDraftInfo = archivesRPC.getDraftInfo
     beaker.archives.listDrafts = archivesRPC.listDrafts
-    beaker.archives.setActiveDraft = archivesRPC.setActiveDraft
     beaker.archives.addDraft = archivesRPC.addDraft
     beaker.archives.removeDraft = archivesRPC.removeDraft
     beaker.archives.getTemplate = archivesRPC.getTemplate

--- a/web-apis/manifests/internal/archives.js
+++ b/web-apis/manifests/internal/archives.js
@@ -17,7 +17,6 @@ module.exports = {
   // drafts
   getDraftInfo: 'promise',
   listDrafts: 'promise',
-  setActiveDraft: 'promise',
   addDraft: 'promise',
   removeDraft: 'promise',
 


### PR DESCRIPTION
The "active draft" was meant to be a simple way to change which archive in a set of drafts is actively syncing to the local folder. After a few passes at the UX, we felt like this approach might be more complex than simply having users manage the local sync folder themselves, since it required us to introduce a new concept (the "active" draft).

Removing this concept makes drafts much less ambitious, which I think is a good thing.