### PR TITLE
feat(datpeers): add ability to get own peer id

### DIFF
--- a/dat/daemon/index.js
+++ b/dat/daemon/index.js
@@ -353,6 +353,7 @@ const RPC_API = {
 
   ext_listPeers: async (key, ...args) => datExtensions.listPeers(getArchive(key), ...args),
   ext_getPeer: async (key, ...args) => datExtensions.getPeer(getArchive(key), ...args),
+  ext_getOwnPeerId: () => datEncoding.toStr(networkId),
   ext_broadcastEphemeralMessage: async (key, ...args) => datExtensions.broadcastEphemeralMessage(getArchive(key), ...args),
   ext_sendEphemeralMessage: async (key, ...args) => datExtensions.sendEphemeralMessage(getArchive(key), ...args),
   ext_getSessionData: async (key, ...args) => datExtensions.getSessionData(getArchive(key), ...args),

--- a/dat/daemon/manifest.js
+++ b/dat/daemon/manifest.js
@@ -42,6 +42,7 @@ module.exports = {
 
   ext_listPeers: 'promise',
   ext_getPeer: 'promise',
+  ext_getOwnPeerId: 'promise',
   ext_broadcastEphemeralMessage: 'promise',
   ext_sendEphemeralMessage: 'promise',
   ext_getSessionData: 'promise',

--- a/web-apis/bg/experimental/dat-peers.js
+++ b/web-apis/bg/experimental/dat-peers.js
@@ -57,6 +57,11 @@ module.exports = {
     await globals.permsAPI.checkLabsPerm(Object.assign({sender: this.sender}, LAB_PERMS_OBJ))
     var archive = await getSenderArchive(this.sender)
     return datLibrary.getDaemon().ext_createDatPeersStream(archive.key.toString('hex'))
+  },
+
+  async getOwnPeerId () {
+    await globals.permsAPI.checkLabsPerm(Object.assign({sender: this.sender}, LAB_PERMS_OBJ))
+    return datLibrary.getDaemon().ext_getOwnPeerId()
   }
 }
 

--- a/web-apis/fg/experimental.js
+++ b/web-apis/fg/experimental.js
@@ -84,6 +84,7 @@ exports.setup = function (rpc) {
     experimental.datPeers.broadcast = datPeersRPC.broadcast
     experimental.datPeers.getSessionData = datPeersRPC.getSessionData
     experimental.datPeers.setSessionData = datPeersRPC.setSessionData
+    experimental.datPeers.getOwnPeerId = datPeersRPC.getOwnPeerId
   }
 
   return experimental

--- a/web-apis/manifests/external/experimental/dat-peers.js
+++ b/web-apis/manifests/external/experimental/dat-peers.js
@@ -5,5 +5,6 @@ module.exports = {
   send: 'promise',
   getSessionData: 'promise',
   setSessionData: 'promise',
+  getOwnPeerId: 'promise',
   createEventStream: 'readable'
 }


### PR DESCRIPTION
This PR addresses https://github.com/beakerbrowser/beaker/issues/1182

It adds an `experimental.datPeers.getOwnPeerId` method that returns the stringified peerId of the current user.

Being new to the code base, I made some assumptions regarding the implementation. I hope this method is okay and that I haven't missed anything. Would be happy to change stuff around as needed.

Tests were added in an accompanying PR (linked below).

EDIT: test PR https://github.com/beakerbrowser/beaker/pull/1298