### PR TITLE
Translating the Header object for globalFetch's RPC call.

### DIFF
--- a/web-apis/bg/experimental/global-fetch.js
+++ b/web-apis/bg/experimental/global-fetch.js
@@ -17,7 +17,7 @@ const LAB_API_ID = 'globalFetch'
 module.exports = {
   async fetch (reqOptions, reqBody) {
     // parse url
-    var urlp = new URL(reqOptions.url)
+    let urlp = new URL(reqOptions.url)
     reqOptions.protocol = urlp.protocol
     reqOptions.host = urlp.host
     reqOptions.path = urlp.pathname + urlp.search + urlp.hash
@@ -36,15 +36,15 @@ module.exports = {
 
     return new Promise((resolve, reject) => {
       // start request
-      var proto = urlp.protocol === 'https:' ? https : http
-      var reqStream = proto.request(reqOptions, resStream => {
+      let proto = urlp.protocol === 'https:' ? https : http
+      let reqStream = proto.request(reqOptions, resStream => {
         resStream.pipe(concat(resStream, resBody => {
           // resolve with response
           resolve({
             status: resStream.statusCode,
             statusText: resStream.statusMessage,
             headers: resStream.headers,
-            body: resBody
+            body: (resStream.statusCode != 204 && resStream.statusCode != 304 ? resBody : null)
           })
         }))
 

--- a/web-apis/fg/experimental.js
+++ b/web-apis/fg/experimental.js
@@ -31,15 +31,18 @@ exports.setup = function (rpc) {
 
     // experimental.globalFetch
     experimental.globalFetch = async function globalFetch (input, init) {
-      var request = new Request(input, init)
+      let request = new Request(input, init)
       if (request.method !== 'HEAD' && request.method !== 'GET') {
         throw new Error('Only HEAD and GET requests are currently supported by globalFetch()')
       }
       try {
-        var responseData = await globalFetchRPC.fetch({
+        if (request.compress)
+          request.headers.set('accept-encoding', 'gzip,deflate')
+        let headers = {}
+        request.headers.forEach((val, name) => headers[name] = val)
+        let responseData = await globalFetchRPC.fetch({headers,
           method: request.method,
-          url: request.url,
-          headers: request.headers
+          url: request.url
         })
         return new Response(responseData.body, responseData)
       } catch (e) {


### PR DESCRIPTION
So - sending headers over globalFetch doesn't actually work. In `fg`, the headers are a Fetch API Headers object. These don't make it through RPC - perhaps because `bg` doesn't have the Headers class. Whatever the case - this code builds a vanilla Object that gets passed.

This also handles 204 and 304 status codes (which are null body status codes). This work is to allow me to cache data in an RSS reader-type Dat app.

Cool - lots of love.
- kicks